### PR TITLE
Compatibility with 8.19 and 8.18

### DIFF
--- a/tests/Makefile
+++ b/tests/Makefile
@@ -13,7 +13,7 @@ coc: core.ml core.mli top.ml newman.coc
 	@echo '******************** End of test ***********************'
 
 clean:
-	rm core.ml core.mli *.cmx *.cmi *.o
+	rm -f core.ml core.mli *.cmx *.cmi *.o
 
 # Building core.ml : we do not want an Extract.vo to be produced
 core.ml core.mli: Extract.v

--- a/theories/Can.v
+++ b/theories/Can.v
@@ -120,7 +120,7 @@ simple induction 2.
 simple induction 3.
 intros.
 generalize H6.
-elimtype (sn m); intros.
+cut (sn m); [intros H'; elim H' | ]; intros.
 apply (clos_exp X); intros; auto with coc core arith datatypes.
 red in |- *; intros; discriminate.
 

--- a/theories/Conv_Dec.v
+++ b/theories/Conv_Dec.v
@@ -96,8 +96,8 @@ Qed.
    forall t : term, sn t -> {u : term | red t u &  normal u}.
 Proof.
 intros.
-elimtype (Acc ord_norm t).
-clear H t.
+cut (Acc ord_norm t); [intros _H'; elim _H' |].
+clear _H' H t.
 intros [s| n| T t| u v| T U] _ norm_rec.
 exists (Srt s); auto with coc.
 red in |- *; red in |- *; intros.

--- a/theories/Expr.v
+++ b/theories/Expr.v
@@ -19,8 +19,6 @@ Require Import MyList.
 Require Import Termes.
 Require Export Names.
 
-Unset Standard Proposition Elimination Names.
-
   (* external level *)
 
   Inductive expr : Set :=
@@ -221,7 +219,7 @@ exists (REF x).
 apply eqv_ref.
 apply name_unique_first; auto with coc core arith datatypes.
 
-elimtype False.
+exfalso.
 inversion_clear H0.
 generalize n b H1.
 elim l; simpl in |- *.

--- a/theories/Int_term.v
+++ b/theories/Int_term.v
@@ -50,25 +50,21 @@ elim (le_gt_dec (S k) n); intros.
 elim (le_gt_dec k n); intros.
 rewrite simpl_subst; auto with coc core arith sets.
 replace (n - k) with (S (n - S k)); auto with coc core arith sets.
-rewrite minus_Sn_m; auto with coc core arith sets.
+lia.
 
-elim le_not_gt with k n; auto with coc core arith sets.
-
-simpl in |- *.
 elim (lt_eq_lt_dec k n); [ intro Hlt_eq | intro Hlt ].
-elim Hlt_eq; clear Hlt_eq; [ intro Hlt | intro Heq ].
-absurd (n <= k); auto with coc core arith sets.
+elim Hlt_eq; clear Hlt_eq. lia.
 
-elim (le_gt_dec k n); [ intro Hle | intro Hgt ];
- auto with coc core arith sets.
-elim Heq.
-replace (k - k) with 0; auto with coc core arith sets.
-
-inversion_clear Heq in Hgt.
-elim gt_irrefl with n; auto with coc core arith sets.
-
-elim (le_gt_dec k n); intros; auto with coc core arith sets.
-absurd (k <= n); auto with coc core arith sets.
+intros ?; subst.
+replace (n - n) with 0; auto with coc core arith sets. simpl.
+elim (le_gt_dec n n); [ intro Hle | intro Hgt ];
+ auto with coc core arith sets; try lia.
+elim (lt_eq_lt_dec n n); [|];
+ auto with coc core arith sets; try lia.
+intuition lia.
+elim (le_gt_dec k n); intros; auto with coc core arith sets; [lia|].
+simpl.
+elim (lt_eq_lt_dec k n); try intuition lia.
 
 rewrite H; rewrite H0; auto with coc core arith sets.
 

--- a/theories/Machine.v
+++ b/theories/Machine.v
@@ -716,7 +716,7 @@ simple induction err; intros.
 elim find_free_var with (glob_names s); intros.
 elim expr_of_term with t (glob_names s); intros;
  auto with coc core arith datatypes.
-elimtype {si : state | state_ext x t s si}; intros.
+cut {si : state | state_ext x t s si}; [intros H'; elim H' | ]; intros.
 elim H with x1; intros.
 exists (Punder x x0 x2).
 apply Tpe_under; auto with coc core arith datatypes.

--- a/theories/MyList.v
+++ b/theories/MyList.v
@@ -14,11 +14,9 @@
 (* 02110-1301 USA                                                     *)
 
 
-Require Import Le.
-Require Import Gt.
+Require Import Arith.
 Require Export List.
 
-Unset Standard Proposition Elimination Names.
 Global Set Asymmetric Patterns.
 
 Section Listes.

--- a/theories/Names.v
+++ b/theories/Names.v
@@ -16,6 +16,7 @@
 
 Require Import Arith.
 Require Import MyList.
+Require Import Lia.
 Require Export MlTypes.
 
 
@@ -168,10 +169,8 @@ inversion H3; auto with coc.
 constructor; eauto.
 
 red in |- *; intros.
-apply (le_Sn_n n).
-pattern n at 2 in |- *.
-replace n with m; auto with coc core arith datatypes.
-apply inj_var_of_nat; auto with coc core arith datatypes.
+enough (m = n) by lia.
+revert H0; apply inj_var_of_nat.
 Defined.
 
 

--- a/theories/Strong_Norm.v
+++ b/theories/Strong_Norm.v
@@ -22,6 +22,7 @@ Require Import Can.
 Require Import Int_term.
 Require Import Int_typ.
 Require Import Int_stab.
+Require Import PeanoNat.
 
 Load "ImpVar".
 
@@ -58,7 +59,7 @@ inversion_clear H2.
 
 elim (le_gt_dec 0 v); [ intro Hle | intro Hgt ].
 rewrite lift0.
-elim minus_n_O with v.
+rewrite Nat.sub_0_r.
 elim H1; intros.
 rewrite H3.
 generalize ip it H2.

--- a/theories/Termes.v
+++ b/theories/Termes.v
@@ -15,9 +15,10 @@
 
 
 
-Require Export Arith.
+Require Export PeanoNat.
 Require Export Compare_dec.
 Require Export Relations.
+Require Export Lia.
 
 Implicit Types i k m n p : nat.
 
@@ -234,33 +235,20 @@ Qed.
   Lemma subst_ref_lt : forall u n k, k > n -> subst_rec u (Ref n) k = Ref n.
 simpl in |- *; intros.
 elim (lt_eq_lt_dec k n); [ intro a | intro b; auto with coc core arith sets ].
-elim a; clear a; [ intro a | intro b ].
-absurd (k <= n); auto with coc core arith sets.
-
-inversion_clear b in H.
-elim gt_irrefl with n; auto with coc core arith sets.
+intuition lia.
 Qed.
 
 
   Lemma subst_ref_gt :
    forall u n k, n > k -> subst_rec u (Ref n) k = Ref (pred n).
-simpl in |- *; intros.
-elim (lt_eq_lt_dec k n); [ intro a | intro b ].
-elim a; clear a; [ intro a; auto with coc core arith sets | intro b ].
-inversion_clear b in H.
-elim gt_irrefl with n; auto with coc core arith sets.
-
-absurd (k <= n); auto with coc core arith sets.
+    simpl in |- *; intros.
+elim (lt_eq_lt_dec k n); intuition lia.
 Qed.
 
 
   Lemma subst_ref_eq : forall u n, subst_rec u (Ref n) n = lift n u.
 intros; simpl in |- *.
-elim (lt_eq_lt_dec n n); [ intro a | intro b ].
-elim a; intros; auto with coc core arith sets.
-elim lt_irrefl with n; auto with coc core arith sets.
-
-elim gt_irrefl with n; auto with coc core arith sets.
+elim (lt_eq_lt_dec n n); intuition lia.
 Qed.
 
 
@@ -288,22 +276,11 @@ Qed.
    i <= k + n ->
    k <= i -> lift_rec p (lift_rec n M k) i = lift_rec (p + n) M k.
 simple induction M; simpl in |- *; intros; auto with coc core arith sets.
-elim (le_gt_dec k n); intros.
-rewrite lift_ref_ge; auto with coc core arith sets.
+elim (le_gt_dec k n); intros. 
+rewrite lift_ref_ge; solve [auto with coc core arith sets | lia].
+rewrite lift_ref_lt; auto with coc core arith sets. lia.
 
-rewrite plus_comm; apply le_trans with (k + n0);
- auto with coc core arith sets.
-
-rewrite lift_ref_lt; auto with coc core arith sets.
-apply le_gt_trans with k; auto with coc core arith sets.
-
-rewrite H; auto with coc core arith sets; rewrite H0; simpl in |- *;
- auto with coc core arith sets.
-
-rewrite H; auto with coc core arith sets; rewrite H0; simpl in |- *;
- auto with coc core arith sets.
-
-rewrite H; auto with coc core arith sets; rewrite H0; simpl in |- *;
+all : rewrite H; auto with coc core arith sets; rewrite H0; simpl in |- *;
  auto with coc core arith sets.
 Qed.
 
@@ -322,21 +299,19 @@ simple induction M; simpl in |- *; intros; auto with coc core arith sets.
 elim (le_gt_dec k n); elim (le_gt_dec i n); intros.
 rewrite lift_ref_ge; auto with coc core arith sets.
 rewrite lift_ref_ge; auto with coc core arith sets.
-elim plus_assoc_reverse with p n0 n.
-elim plus_assoc_reverse with n0 p n.
-elim plus_comm with p n0; auto with coc core arith sets.
+f_equal. lia.
 
-apply le_trans with n; auto with coc core arith sets.
+apply Nat.le_trans with n; auto with coc core arith sets.
 
 absurd (i <= n); auto with coc core arith sets.
-apply le_trans with k; auto with coc core arith sets.
+apply Nat.le_trans with k; auto with coc core arith sets.
 
 rewrite lift_ref_ge; auto with coc core arith sets.
 rewrite lift_ref_lt; auto with coc core arith sets.
 
 rewrite lift_ref_lt; auto with coc core arith sets.
 rewrite lift_ref_lt; auto with coc core arith sets.
-apply le_gt_trans with k; auto with coc core arith sets.
+lia.
 
 rewrite H; auto with coc core arith sets; rewrite H0;
  auto with coc core arith sets.
@@ -368,10 +343,10 @@ simple induction M; simpl in |- *; intros; auto with coc core arith sets.
 elim (le_gt_dec k n); intros.
 rewrite subst_ref_gt; auto with coc core arith sets.
 red in |- *; red in |- *.
-apply le_trans with (S (n0 + k)); auto with coc core arith sets.
+apply Nat.le_trans with (S (n0 + k)); auto with coc core arith sets.
 
 rewrite subst_ref_lt; auto with coc core arith sets.
-apply le_gt_trans with k; auto with coc core arith sets.
+lia.
 
 rewrite H; auto with coc core arith sets; rewrite H0;
  auto with coc core arith sets.
@@ -412,7 +387,7 @@ rewrite subst_ref_gt; auto with coc core arith sets.
 elim plus_n_Sm with n0 n1.
 auto with coc core arith sets.
 
-apply le_trans with p; auto with coc core arith sets.
+apply Nat.le_trans with p; auto with coc core arith sets.
 
 simple induction 1.
 rewrite subst_ref_eq.
@@ -420,7 +395,7 @@ unfold lift in |- *.
 rewrite simpl_lift_rec; auto with coc core arith sets.
 
 absurd (k <= n); auto with coc core arith sets.
-apply le_trans with p; auto with coc core arith sets.
+apply Nat.le_trans with p; auto with coc core arith sets.
 elim Hlt_eq; auto with coc core arith sets.
 simple induction 1; auto with coc core arith sets.
 
@@ -429,7 +404,7 @@ rewrite subst_ref_lt; auto with coc core arith sets.
 
 rewrite lift_ref_lt; auto with coc core arith sets.
 rewrite subst_ref_lt; auto with coc core arith sets.
-apply le_gt_trans with p; auto with coc core arith sets.
+lia.
 
 simpl in |- *.
 rewrite plus_n_Sm.
@@ -469,8 +444,8 @@ rewrite lift_ref_ge; auto with coc core arith sets.
 elim plus_n_Sm with n0 n1.
 rewrite subst_ref_gt; auto with coc core arith sets.
 red in |- *; red in |- *; apply le_n_S.
-apply le_trans with (n0 + (p + k)); auto with coc core arith sets.
-apply le_trans with (p + k); auto with coc core arith sets.
+apply Nat.le_trans with (n0 + (p + k)); auto with coc core arith sets.
+apply Nat.le_trans with (p + k); auto with coc core arith sets.
 
 rewrite lift_ref_lt; auto with coc core arith sets.
 rewrite subst_ref_gt; auto with coc core arith sets.
@@ -526,7 +501,7 @@ inversion_clear Hlt.
 
 rewrite subst_ref_gt; auto with coc core arith sets.
 rewrite subst_ref_gt; auto with coc core arith sets.
-apply gt_le_trans with (p + n0); auto with coc core arith sets.
+lia.
 
 simple induction 1.
 rewrite subst_ref_eq; auto with coc core arith sets.


### PR DESCRIPTION
This pull request removes the use of deprecated arithmetic lemmas (e.g. Gt.v) and `elimtype` so the project compiles with Coq 8.19.1 and 8.18.0 without warnings.

For the deprecated lemmas, I either replaced them with the up-to-date ones that are still in the stdlib or simply used `lia` to solve the goal. The removal of `elimtype` follows the exact same pattern from <https://github.com/coq/coq/pull/16904/commits/f07f8aa9dd217670efc36f3159ca4060c20bd359>

I also added the `-f` flag to the `rm` command for the test Makefile so running `make clean` doesn't always give an error in the absence of `.mli` files in the test directory.